### PR TITLE
Fix sending commands for 1.19

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 minecraft_version=1.19
 forge_version=41.0.5
-mod_version=1.11.0
+mod_version=1.11.1
 
 org.gradle.jvmargs=-Xmx4G
 org.gradle.daemon=false

--- a/src/main/java/dmillerw/menu/data/click/ClickActionCommand.java
+++ b/src/main/java/dmillerw/menu/data/click/ClickActionCommand.java
@@ -22,13 +22,15 @@ public class ClickActionCommand implements ClickAction.IClickAction {
     public void onClicked() {
         Minecraft mc = Minecraft.getInstance();
         LocalPlayer player = mc.player;
-        String parsedCommand = command.replace("@p", player.getName().getString());
+        String parsedCommand = command
+                .replaceAll("^/+", "")
+                .replace("@p", player.getName().getString());
 
         if (clipboard) {
             mc.keyboardHandler.setClipboard(parsedCommand);
             player.displayClientMessage(Component.translatable("mine_menu.clipboardCopy"), true);
         } else {
-            player.chat(parsedCommand);
+            player.command(parsedCommand);
         }
     }
 

--- a/src/main/java/dmillerw/menu/data/click/ClickActionCommand.java
+++ b/src/main/java/dmillerw/menu/data/click/ClickActionCommand.java
@@ -22,14 +22,13 @@ public class ClickActionCommand implements ClickAction.IClickAction {
     public void onClicked() {
         Minecraft mc = Minecraft.getInstance();
         LocalPlayer player = mc.player;
-        String parsedCommand = command
-                .replaceAll("^/+", "")
-                .replace("@p", player.getName().getString());
+        String parsedCommand = command.replace("@p", player.getName().getString());
 
         if (clipboard) {
             mc.keyboardHandler.setClipboard(parsedCommand);
             player.displayClientMessage(Component.translatable("mine_menu.clipboardCopy"), true);
         } else {
+            parsedCommand = parsedCommand.replaceAll("^/+", "");
             player.command(parsedCommand);
         }
     }


### PR DESCRIPTION
Changed to player.command method, which makes sending a command work again for Minecraft 1.19. Resolves issue #131