### PR TITLE
Only render the menu once per render pass

### DIFF
--- a/src/main/java/dmillerw/menu/handler/ClientTickHandler.java
+++ b/src/main/java/dmillerw/menu/handler/ClientTickHandler.java
@@ -19,6 +19,7 @@ import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.event.RenderGuiOverlayEvent;
+import net.minecraftforge.client.gui.overlay.VanillaGuiOverlay;
 import net.minecraftforge.event.TickEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -46,6 +47,10 @@ public class ClientTickHandler {
     @SubscribeEvent
     public static void onRenderOverlay(RenderGuiOverlayEvent event) {
         if (!(event instanceof RenderGuiOverlayEvent.Post)) {
+            return;
+        }
+
+        if (!(event.getOverlay().id().equals(VanillaGuiOverlay.PLAYER_LIST.id()))) {
             return;
         }
 


### PR DESCRIPTION
RenderGuiOverlayEvent.Post fires once per HUD component (health, armor, hotbar, scoreboard, boss bar, player list, ...). This means that the menu was rendered more than 25 times when once would be sufficient.

Arbitrarily choose the player list component as an anchor.

This becomes an issue when this mod is combined in combination with my mod Auto HUD, as this mod moves some of these components in different directions. That leads to the menu being duplicated on screen, offset off each other.

Closes Crendgrim/AutoHUD#74