### PR TITLE
Change from ServerWorldEvents to ClientWorldEvents

### DIFF
--- a/fabric/src/main/java/com/girafi/minemenu/client/ClientHandler.java
+++ b/fabric/src/main/java/com/girafi/minemenu/client/ClientHandler.java
@@ -7,6 +7,7 @@ import com.girafi.minemenu.helper.KeyboardHandlerHelper;
 import com.girafi.minemenu.util.MineMenuKeybinds;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.fabricmc.loader.api.FabricLoader;
@@ -17,7 +18,7 @@ public class ClientHandler implements ClientModInitializer {
     public void onInitializeClient() {
         MineMenuCommon.registerPackets();
         MineMenuCommon.loadMenuJson(FabricLoader.getInstance().getGameDir().toFile());
-        ServerWorldEvents.LOAD.register(((phase, load) -> MineMenuCommon.setupMenuLoader(load.registryAccess())));
+        ClientWorldEvents.AFTER_CLIENT_WORLD_CHANGE.register(((phase, load) -> MineMenuCommon.setupMenuLoader(load.registryAccess())));
         KeyBindingHelper.registerKeyBinding(MineMenuKeybinds.RADIAL_MENU_OPEN);
 
         ClientTickEvents.END_CLIENT_TICK.register((mc) -> {

--- a/fabric/src/main/java/com/girafi/minemenu/client/ClientHandler.java
+++ b/fabric/src/main/java/com/girafi/minemenu/client/ClientHandler.java
@@ -9,7 +9,6 @@ import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientWorldEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
-import net.fabricmc.fabric.api.event.lifecycle.v1.ServerWorldEvents;
 import net.fabricmc.loader.api.FabricLoader;
 
 public class ClientHandler implements ClientModInitializer {


### PR DESCRIPTION
Currently on Fabric, the code that loads the menu is run only when the integrated server loads the world (aka loading singleplayer world), this means joining a server will not load the menu as the integrated server is not running.
This PR changes the logic to be on the client side when a world changes instead on server, making it so you don't need to load a singleplayer world in order to have the menu options after joining server.
Fixes #197 